### PR TITLE
Add status_name prefix parameter to node_alive_server

### DIFF
--- a/launch/server.launch
+++ b/launch/server.launch
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 	<rosparam command="load" file="$(find node_alive)/parameters/neglect_nodes.yaml" />
-	<node name="node_alive_server" type="node_alive_server" pkg="node_alive" />
+	<node name="node_alive_server" type="node_alive_server" pkg="node_alive" >
+		<param name="status_prefix" value="node_alive" />
+	</node>
 </launch>

--- a/src/node_alive_server
+++ b/src/node_alive_server
@@ -34,11 +34,14 @@ class NodeAliveServer():
 
     re_ping_node = re.compile('pinging ([^ ]+) with a timeout of \d+.\d+s\s*xmlrpc reply from')
 
+    status_prefix = ""
+
     def __init__(self):
         try:
             self.neglect_nodes = rospy.get_param('node_alive/neglect_nodes')
         except:
             self.neglect_nodes = []
+        self.status_prefix = rospy.get_param('~status_prefix', 'node_alive')
 
         self.pub = rospy.Publisher('diagnostics', diagnostic_msgs.msg.DiagnosticArray, queue_size=10)
         self.sub = rospy.Subscriber("check_alive_nodes", String, self.callback)
@@ -98,7 +101,7 @@ class NodeAliveServer():
 
             # Create diagnostic mesasge
             statusMsg = diagnostic_msgs.msg.DiagnosticStatus()
-            statusMsg.name = "node_alive%s" % tracked_node
+            statusMsg.name = self.status_prefix + tracked_node
 
             # Determine node status
             if tracked_node in self.alive_nodes:


### PR DESCRIPTION
As discussed at in #5 .

If status_prefix parameter is not defined it will be set to "node_alive" to keep backwards compatibility. I also modified server.launch to include the parameter and set it to node_alive regardless, I think it's a good reference for anyone who could be looking to modify it.